### PR TITLE
HepMC3 is now enabled by default and built by CPM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ option(ENABLE_GZIP "Enable compression of event files" ON)
 option(ENABLE_CASCADE_TEST "Enable executables for testing the cascade" OFF)
 option(ENABLE_POTENTIAL_TEST "Enable executables for testing the potential" OFF)
 option(ENABLE_BSM "Enable the generation of BSM events (Requires Sherap)" ON) 
-option(ENABLE_HEPMC3 "Enable the HepMC3 output format" ON)
+SET(ENABLE_HEPMC3 TRUE)
 
 # Very basic PCH example
 option(ENABLE_PCH "Enable Precompiled Headers" OFF)
@@ -65,11 +65,6 @@ if(ENABLE_BSM)
 # Find Sherpa
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/CMake)
 find_package(SHERPA REQUIRED)
-endif()
-
-if(ENABLE_HEPMC3)
-# Find HepMC3
-find_package(HepMC3 REQUIRED)
 endif()
 
 # Find ROOT if needed

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -72,6 +72,25 @@ CPMAddPackage(
 )
 add_library(yaml::fortran ALIAS yaml-fortran)
 
+CPMAddPackage(
+    NAME HepMC3
+    VERSION 3.2.5
+    GIT_REPOSITORY "https://gitlab.cern.ch/hepmc/HepMC3.git"
+    GIT_TAG 3.2.5
+    OPTIONS
+      "HEPMC3_CXX_STANDARD ${CMAKE_CXX_STANDARD}"
+      "HEPMC3_ENABLE_SEARCH OFF"
+      "HEPMC3_ENABLE_ROOTIO OFF"
+      "HEPMC3_ENABLE_PROTOBUFIO OFF"
+      "HEPMC3_ENABLE_PYTHON OFF"
+      "HEPMC3_BUILD_DOCS OFF"
+      "HEPMC3_BUILD_EXAMPLES OFF"
+      "HEPMC3_INSTALL_EXAMPLES OFF"
+      "HEPMC3_ENABLE_TEST OFF"
+      "HEPMC3_INSTALL_INTERFACES OFF"
+      "HEPMC3_BUILD_STATIC_LIBS OFF"
+)
+
 # Install testing framework
 if(ENABLE_TESTING OR ENABLE_FUZZING)
     # Catch2

--- a/src/Achilles/CMakeLists.txt
+++ b/src/Achilles/CMakeLists.txt
@@ -158,7 +158,7 @@ set_target_properties(${achilles_targets} PROPERTIES # fortran_interface_f
 include(GNUInstallDirs)
 
 install(TARGETS ${achilles_targets} spdlog yaml-cpp fmt #pybind11 fortran_interface_f 
-        EXPORT achilles-targets
+        # EXPORT achilles-targets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -166,7 +166,7 @@ install(TARGETS ${achilles_targets} spdlog yaml-cpp fmt #pybind11 fortran_interf
 )
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/achilles
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(EXPORT achilles-targets
-    FILE achilles-targets.cmake
-    NAMESPACE achilles::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/achilles)
+# install(EXPORT achilles-targets
+#     FILE achilles-targets.cmake
+#     NAMESPACE achilles::
+#     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/achilles)

--- a/src/plugins/HepMC3/CMakeLists.txt
+++ b/src/plugins/HepMC3/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(hepmc3 SHARED HepMC3EventWriter.cc)
-target_include_directories(hepmc3 PUBLIC ${HEPMC3_INCLUDE_DIR})
+# target_include_directories(hepmc3 PUBLIC ${HEPMC3_INCLUDE_DIR})
 target_link_libraries(hepmc3 PRIVATE project_options
-                             PUBLIC ${HEPMC3_LIB} fmt::fmt spdlog::spdlog yaml::cpp)
+                             PUBLIC HepMC3 fmt::fmt spdlog::spdlog yaml::cpp)


### PR DESCRIPTION
Had to remove Achilles-targets export, but do we really need them? We can fix it if needed, but does anything yet need to configure itself against an Achilles install?